### PR TITLE
Fix `contains is not a function`

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
 console.log(require('./')({
-  apple: process.argv.contains('--apple'),
-  short: process.argv.contains('--short')
+  apple: process.argv.includes('--apple'),
+  short: process.argv.includes('--short')
 }))


### PR DESCRIPTION
This pull request fixes this error:

`TypeError: process.argv.contains is not a function`

The CLI tool isn't currently working since it uses `contains` instead of `includes`. I know this is confusing since `classList` use `contains` instead of `includes`. I always mix these two together. We should really have one method name to rule them all.